### PR TITLE
NCSD-3163: Attempt to fix resource dependencies

### DIFF
--- a/Resources/ArmTemplates/template.json
+++ b/Resources/ArmTemplates/template.json
@@ -247,7 +247,7 @@
                 }
             },
             "dependsOn": [
-                "[variables('functionAppInsightsName')]"
+                "[variables('appServicePlanName')]"
             ]
         },
         {
@@ -308,7 +308,7 @@
           "name": "[concat(variables('functionAppInsightsName'), '-failure-anomaly-v2')]",
           "type": "Microsoft.Resources/deployments",
           "dependsOn": [
-              "[variables('functionAppInsightsName')]"
+              "[concat(variables('functionAppInsightsName'), '-metric-exceptions')]"
           ],
           "properties": {
               "mode": "Incremental",


### PR DESCRIPTION
The initial deploy of this template always failed with a resource not found error.
This appeared to be caused by the metric exception alert not being able to find the app insights instance, despite having a dependency to it.
We suspect it's because it's setting up multiple alerts simultaneously, hence the dependency update.

I also noticed that the function app incorrectly depended on the app insights instance, when it should depend on the app service plan.

This change fixes those two issues